### PR TITLE
fix the aci search edge case

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opsmate"
-version = "0.1.39a0"
+version = "0.1.39a1"
 description = "opsmate is a SRE AI assistant"
 authors = [
     { name="Jingkai", email="jingkai@hey.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2897,7 +2897,7 @@ wheels = [
 
 [[package]]
 name = "opsmate"
-version = "0.1.39a0"
+version = "0.1.39a1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
hard to reproduce but it appears to be triggered by

```
grep -En -A 100 -B 100 foo foo.txt
```

which produces:

```
grep: foo.txt: No such file or directory
```