### PR TITLE
Ollama models offline caching

### DIFF
--- a/opsmate/dino/provider/openai.py
+++ b/opsmate/dino/provider/openai.py
@@ -19,7 +19,9 @@ class OpenAIProvider(Provider):
     ]
     reasoning_models = [
         "o1",
+        "o3",
         "o3-mini",
+        "o4-mini",
     ]
     models = chat_models + reasoning_models
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opsmate"
-version = "0.1.55a0"
+version = "0.1.55a1"
 description = "opsmate is a SRE AI assistant"
 authors = [
     { name="Jingkai", email="jingkai@hey.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -3126,7 +3126,7 @@ wheels = [
 
 [[package]]
 name = "opsmate"
-version = "0.1.55a0"
+version = "0.1.55a1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
so that it doesn't crash the whole program whenever the ollama serve process is offline

this issue is actually surfaced by the CI failure - https://github.com/jingkaihe/opsmate/pull/165#issuecomment-2812356676